### PR TITLE
expose simple scanner API for external consumption

### DIFF
--- a/cmd/cvscan/scan.go
+++ b/cmd/cvscan/scan.go
@@ -1,124 +1,43 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/IBM/cvscan/internal/scan"
+	"github.com/IBM/cvscan/pkg/scan"
 	"github.com/IBM/cvscan/pkg/version"
 )
 
-type scanCmd struct {
-	opts            metav1.ListOptions
-	extra           bool
-	clusterWideOnly bool
-	configOverrides clientcmd.ConfigOverrides
-	kubeconfig      string
-	version         bool
-}
-
 func newScanCmd() *cobra.Command {
-	s := &scanCmd{}
+	s := scan.NewScanner()
+	versionFlag := false
 
 	cmd := &cobra.Command{
 		Use:   "cvscan output_path",
 		Short: "Take a snapshot of live kubernetes resources",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return s.run(args)
+			if versionFlag {
+				fmt.Println(version.Version())
+				return nil
+			}
+
+			return s.Run(args)
 		},
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&s.opts.LabelSelector, "selector", "l", "", "Selector (label query) to filter on")
-	flags.StringVar(&s.opts.FieldSelector, "field-selector", "", "Selector (field query) to filter on")
-	flags.StringVar(&s.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")
-	flags.BoolVar(&s.clusterWideOnly, "cluster-wide-only", false, "ignore all namespace-scoped resources")
-	flags.BoolVar(&s.version, "version", false, "print version information and exit")
+	flags.StringVarP(&s.Opts.LabelSelector, "selector", "l", "", "Selector (label query) to filter on")
+	flags.StringVar(&s.Opts.FieldSelector, "field-selector", "", "Selector (field query) to filter on")
+	flags.StringVar(&s.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")
+	flags.BoolVar(&s.ClusterWideOnly, "cluster-wide-only", false, "ignore all namespace-scoped resources")
+	flags.BoolVar(&versionFlag, "version", false, "print version information and exit")
 
-	flags.BoolVar(&s.extra, "extra", false, "Flag to enable collecting extra resources")
+	flags.BoolVar(&s.Extra, "extra", false, "Flag to enable collecting extra resources")
 	flags.MarkHidden("extra")
 
-	clientcmd.BindOverrideFlags(&s.configOverrides, flags, clientcmd.RecommendedConfigOverrideFlags(""))
+	clientcmd.BindOverrideFlags(&s.ConfigOverrides, flags, clientcmd.RecommendedConfigOverrideFlags(""))
 
 	return cmd
-}
-
-func (sCmd *scanCmd) run(args []string) error {
-	if sCmd.version {
-		fmt.Println(version.Version())
-		return nil
-	}
-
-	if len(args) == 0 {
-		return errors.New("output_path argument is required")
-	}
-	outputPath := args[0]
-
-	err := os.MkdirAll(outputPath, os.ModePerm)
-	if err != nil {
-		return fmt.Errorf("creating output directory: %v", err)
-	}
-
-	config, err := sCmd.getClusterConfig()
-	if err != nil {
-		return fmt.Errorf("getting config: %v", err)
-	}
-
-	s, err := scan.New(config, sCmd.clusterWideOnly)
-	if err != nil {
-		return fmt.Errorf("initialize scanner: %v", err)
-	}
-
-	err = s.WriteCaps(sCmd.configOverrides.Context.Namespace, sCmd.opts, outputPath)
-	if err != nil {
-		return fmt.Errorf("writing capabilities: %v", err)
-	}
-
-	if sCmd.extra {
-		err := s.ListAll("", sCmd.opts, outputPath)
-		if err != nil {
-			return fmt.Errorf("listing resources with options: %v", err)
-		}
-
-		err = s.ListAll(sCmd.configOverrides.Context.Namespace, metav1.ListOptions{}, outputPath)
-		if err != nil {
-			return fmt.Errorf("listing resources in namespace: %v", err)
-		}
-	} else {
-		err = s.ListAll(sCmd.configOverrides.Context.Namespace, sCmd.opts, outputPath)
-		if err != nil {
-			return fmt.Errorf("listing resources: %v", err)
-		}
-	}
-	return nil
-}
-
-func (sCmd *scanCmd) getClusterConfig() (*rest.Config, error) {
-
-	//use kubeconfig flag if present
-	if sCmd.kubeconfig != "" {
-		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-		loadingRules.ExplicitPath = sCmd.kubeconfig
-		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &sCmd.configOverrides)
-		return kubeConfig.ClientConfig()
-	}
-	//if no kubeconfig flag, check if in cluster
-	//otherwise load from default config path
-	config, err := rest.InClusterConfig()
-	if err == nil {
-		return config, nil
-	} else if err == rest.ErrNotInCluster {
-		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &sCmd.configOverrides)
-		return kubeConfig.ClientConfig()
-	} else {
-		return nil, err
-	}
-
 }

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -1,0 +1,94 @@
+package scan
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/IBM/cvscan/internal/scan"
+)
+
+type Scanner struct {
+	Opts            metav1.ListOptions
+	Extra           bool
+	ClusterWideOnly bool
+	ConfigOverrides clientcmd.ConfigOverrides
+	Kubeconfig      string
+}
+
+func NewScanner() *Scanner {
+	return &Scanner{}
+}
+
+func (sCmd *Scanner) Run(args []string) error {
+	if len(args) == 0 {
+		return errors.New("output_path argument is required")
+	}
+	outputPath := args[0]
+
+	err := os.MkdirAll(outputPath, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("creating output directory: %v", err)
+	}
+
+	config, err := sCmd.getClusterConfig()
+	if err != nil {
+		return fmt.Errorf("getting config: %v", err)
+	}
+
+	s, err := scan.New(config, sCmd.ClusterWideOnly)
+	if err != nil {
+		return fmt.Errorf("initialize scanner: %v", err)
+	}
+
+	err = s.WriteCaps(sCmd.ConfigOverrides.Context.Namespace, sCmd.Opts, outputPath)
+	if err != nil {
+		return fmt.Errorf("writing capabilities: %v", err)
+	}
+
+	if sCmd.Extra {
+		err := s.ListAll("", sCmd.Opts, outputPath)
+		if err != nil {
+			return fmt.Errorf("listing resources with options: %v", err)
+		}
+
+		err = s.ListAll(sCmd.ConfigOverrides.Context.Namespace, metav1.ListOptions{}, outputPath)
+		if err != nil {
+			return fmt.Errorf("listing resources in namespace: %v", err)
+		}
+	} else {
+		err = s.ListAll(sCmd.ConfigOverrides.Context.Namespace, sCmd.Opts, outputPath)
+		if err != nil {
+			return fmt.Errorf("listing resources: %v", err)
+		}
+	}
+	return nil
+}
+
+func (sCmd *Scanner) getClusterConfig() (*rest.Config, error) {
+
+	//use kubeconfig flag if present
+	if sCmd.Kubeconfig != "" {
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		loadingRules.ExplicitPath = sCmd.Kubeconfig
+		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &sCmd.ConfigOverrides)
+		return kubeConfig.ClientConfig()
+	}
+	//if no kubeconfig flag, check if in cluster
+	//otherwise load from default config path
+	config, err := rest.InClusterConfig()
+	if err == nil {
+		return config, nil
+	} else if err == rest.ErrNotInCluster {
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &sCmd.ConfigOverrides)
+		return kubeConfig.ClientConfig()
+	} else {
+		return nil, err
+	}
+
+}


### PR DESCRIPTION
This change is needed to expose the scanning logic via a simple API so that external tools can consume it.